### PR TITLE
Automatic upload of binary wheels to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,7 @@
 name: Build and upload to PyPI
 
-# Publish when a (published) GitHub Release is created, use the following:
+# Publish only when a (published) GitHub Release is created
 on:
-  push:
-  pull_request:
   release:
     types:
       - published

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,60 @@
+name: Build and upload to PyPI
+
+# Publish when a (published) GitHub Release is created, use the following:
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    #if: github.event_name == 'push'
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.cibuildwheel]
+# Skip 32-bit builds
+# Disable building PyPy wheels on all platforms
+skip = ["*-win32", "*-manylinux_i686", "pp*"]
+#build = "cp36-manylinux_i686"


### PR DESCRIPTION
When a release is created, 
binary wheels are built for a matrix of

* Python 3.6, 3.7, 3.8, 3.9, 3.10,
* Ubuntu 20.04, windows-2019, macos-10.15.

Only 64-bit os are supported.
For Linux, manylinux2014_x86_64 wheels musllinux_x86_64 wheels are built.
For Mac, Apple M1 is not supported yet.
The built wheels are uploaded to PyPI. 