### PR TITLE
Automatic build of binary wheels and upload to PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,59 @@
+name: Build and upload to PyPI
+
+# Publish only when a (published) GitHub Release is created
+on:
+  #push:
+  release:
+    types:
+      - published
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    #if: github.event_name == 'push'
+    # alternatively, to publish when a GitHub Release is created, use the following rule:
+    # if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip_existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.cibuildwheel]
+# Skip 32-bit builds on windows and PyPy
+# Only cp310-* will be built (for now)
+#skip = ["*-win32", "pp*"]
+skip = ["cp36*", "cp37*", "cp38*", "cp39*", "*-win32", "pp*"]
+
+# Build `universal2` and `arm64` wheels on an Intel runner.
+# Note that the `arm64` wheel and the `arm64` part of the `universal2`
+# wheel cannot be tested in this configuration.
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2", "arm64"]
+
+# Build only x86_64 wheels for Linux (bulding arm64 wheels somehow failed)
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]


### PR DESCRIPTION
When a release is created, 
binary wheels are built for a matrix of

* Python 3.10 (<3.10 are disable for now)
* Ubuntu 20.04, windows-2019, macos-10.15.

For Linux, manylinux2014_x86_64 wheels musllinux_x86_64 wheels are built.
Both of Intel and arm mac are supported.
The built wheels are uploaded to PyPI. 