### PR TITLE
Add conda recipe and deployment

### DIFF
--- a/.github/workflows/conda_deply.yml
+++ b/.github/workflows/conda_deply.yml
@@ -1,0 +1,38 @@
+name: Build and upload conda packages
+
+# Triggered a new tag starting with "v" is pushed
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ${{ matrix .os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        #os: [ubuntu-latest]
+        # 3.10 does not work for now.
+        # glibc of linux runner may be too old to install anaconda-client.
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Set up Conda
+      uses: s-weigand/setup-conda@v1
+      with:
+        update-conda: true
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        conda install conda-build anaconda-client -y
+    - name: Bulid and upload
+      env:
+        # Replace this by a new token to change the account to which the packages are updated.
+        ANACONDA_API_TOKEN: ${{secrets.ANACONDA_TOKEN}}
+      run: |
+        conda config --set anaconda_upload yes
+        conda build recipe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,36 @@
+{% set data = load_setup_py_data(setup_file='../setup.py', from_recipe_dir=True) %}
+{% set name = "xprec" %}
+{% set version = data.get("version") %}
+
+package:
+  name: "{{ name|lower }}"
+  version: "{{ version }}"
+
+source:
+  git_url: ../
+
+build:
+  number: 0
+  script: "{{ PYTHON }} -m pip install . -vv"
+
+requirements:
+  host:
+    - numpy >=1.16
+    - pip
+    - python
+  run:
+    - numpy >=1.16
+    - python
+
+test:
+  imports:
+    - xprec
+
+about:
+  home: "https://github.com/tuwien-cms/xprec"
+  license: MIT
+  summary: "xprec precision numpy extension"
+
+extra:
+  recipe-maintainers:
+    - shinaoka

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,12 @@ requirements:
 test:
   imports:
     - xprec
+  source_files:
+    - test/*.py
+  requires:
+    - pytest
+  commands:
+    - pytest test/
 
 about:
   home: "https://github.com/tuwien-cms/xprec"


### PR DESCRIPTION
For the sake of convenience of using SparseIR.jl, I want to upload conda packages to [my own account on anaconda](https://anaconda.org/h.shinaoka) each time a new tag is created.

The following is how it works.
1. When a new tag is detected, workers are created using linux/macos/windows for Python 3.6/3.7/3.8/3.9 on GitHub Actions. (I failed to support Python 3.10 for now due to some conflict in building conda package)
2. In each worker, we build a conda package by parsing setup.py and recipe/meta.yaml.
3. The build packages are uploaded to the anaconda cloud.

You can publish a new version in the same way as before.
1. Update the version number in `__init__.py` and commit the changes.
2. Create a new version tag.
3. Push the commit and the new tag to GitHub.
4. [Then, workers on GitHub Actions will be invoked]

This change is harmless because the resultant packages are uploaded to my own channel/account for now.
We can simply merge this PR, and see how it works when a new tag is created.

For the moment, you can see how it works [here](https://github.com/shinaoka/xprec/actions/runs/1737657901).