### PR TITLE
Upload binary wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,56 @@
+name: Build and upload to PyPI
+
+# Triggered a new tag starting with "v" is pushed
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        #os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip_existing: true
+          ########################
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-20.04, windows-2019, macos-10.15]
-        os: [macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        #os: [macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [tool.cibuildwheel]
 # Skip 32-bit builds on windows and PyPy
-# Only cp39-* will be built (for now)
-skip = ["cp36*", "cp37*", "cp38*", "cp310*", "*-win32", "pp*"]
+skip = ["*-win32", "pp*"]
 
 # Build `universal2` and `arm64` wheels on an Intel runner.
 # Note that the `arm64` wheel and the `arm64` part of the `universal2`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.cibuildwheel]
+# Skip 32-bit builds on windows and PyPy
+# Only cp39-* will be built (for now)
+skip = ["cp36*", "cp37*", "cp38*", "cp310*", "*-win32", "pp*"]
+
+# Build `universal2` and `arm64` wheels on an Intel runner.
+# Note that the `arm64` wheel and the `arm64` part of the `universal2`
+# wheel cannot be tested in this configuration.
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "universal2", "arm64"]
+
+# Build only x86_64 wheels for Linux (bulding arm64 wheels somehow failed)
+[tool.cibuildwheel.linux]
+archs = ["x86_64"]

--- a/pysrc/xprec/__init__.py
+++ b/pysrc/xprec/__init__.py
@@ -16,7 +16,7 @@ Example:
     print(2 * x)
 
 """
-__version__ = "1.1.2"
+__version__ = "1.1.1"
 
 import numpy as _np
 

--- a/pysrc/xprec/__init__.py
+++ b/pysrc/xprec/__init__.py
@@ -16,7 +16,7 @@ Example:
     print(2 * x)
 
 """
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 import numpy as _np
 

--- a/setup.py
+++ b/setup.py
@@ -105,8 +105,7 @@ class BuildExtWithNumpy(build_ext):
             compiler_make = 'msvc'
 
         if platform.system() == 'unix':
-            new_flags = {"-march": "native", "-mtune": "native",
-                         "-Wextra": None, "-std": "c11"}
+            new_flags = {"-Wextra": None, "-std": "c11"}
             self.compiler.compiler_so = update_flags(
                                     self.compiler.compiler_so, new_flags)
 


### PR DESCRIPTION
This PR includes changes for automatic build and upload of binary wheels.
This is triggered by the addition of a new tag.
This PR is independent of #4.

Each time a tag is created, binary wheels for the following platforms are built
and upload to TestPyPI (for testing):
* linux 64 bits (glic, musl libc)
* macos 10.15
* windows-2019
with Python 3.6, 3.7, 3.8, 3.9, 3.10

For a while, binary wheels are NOT uploaded to PyPI safety.
This can be changed later by changing the last few lines in wheels.yml 
```
          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
          skip_existing: true
          ########################
          repository_url: https://test.pypi.org/legacy/
```
as
```
          password: ${{ secrets.PYPI_API_TOKEN }}
          skip_existing: true
```
.

The correctness of this change can be verify by bumping version.