### PR TITLE
Google Colab

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,24 +7,6 @@ on:
       - 'v*'
 
 jobs:
-  build_wheels:
-    name: Build wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
-        #os: [macos-10.15]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
-
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./wheelhouse/*.whl
-
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
@@ -39,7 +21,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_sdist]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -50,7 +32,5 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: true
-          ########################
-          repository_url: https://test.pypi.org/legacy/

--- a/csrc/dd_arith.c
+++ b/csrc/dd_arith.c
@@ -7,7 +7,7 @@
  * Copyright (C) 2021 Markus Wallerberger and others
  * SPDX-License-Identifier: MIT, BSD
  */
-#include "dd_arith.h"
+#include "./dd_arith.h"
 
 // 2**500 and 2**(-500);
 static const double LARGE = 3.273390607896142e+150;


### PR DESCRIPTION
Fixed a compilation error on Google Colab.
The original error message was the following.

```
!pip3 install xprec -vvv
```

```
  creating build/temp.linux-x86_64-3.7
  creating build/temp.linux-x86_64-3.7/csrc
  x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fdebug-prefix-map=/build/python3.7-Y7dWVB/python3.7-3.7.12=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Icsrc -I/usr/local/lib/python3.7/dist-packages/numpy/core/include -I/usr/include/python3.7m -c csrc/_dd_ufunc.c -o build/temp.linux-x86_64-3.7/csrc/_dd_ufunc.o -fopenmp
  csrc/_dd_ufunc.c:16:10: fatal error: dd_arith.h: No such file or directory
   #include "dd_arith.h"
            ^~~~~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
  Building wheel for xprec (PEP 517) ... error
```

Please check [this](https://colab.research.google.com/drive/1zlfTansbb0u3ohHmovchNEEE0RIA3DcH?usp=sharing) out.